### PR TITLE
[frontend] Fix property reference for the offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+package-lock.json

--- a/app/javascript/bundles/HelloWorld/components/HelloWorld.jsx
+++ b/app/javascript/bundles/HelloWorld/components/HelloWorld.jsx
@@ -29,7 +29,7 @@ const HelloWorld = ({
 		<div className="wrapper">
 			<h1>Highlight Within Textarea v2</h1>
       <ContentEditable
-        html={wordsArray.join(' ')}
+        html={wordsArray.join(' ').replace(/(\S+)/gm, '<span>$1</span>')}
         className='no-select'
         disabled={false}       // use true to disable editing
         onKeyDown={onDeleteEditableHtml} // handle innerHTML change

--- a/app/javascript/bundles/HelloWorld/containers/HelloWorldContainer.js
+++ b/app/javascript/bundles/HelloWorld/containers/HelloWorldContainer.js
@@ -24,9 +24,11 @@ const mapDispatchToProps = (dispatch) => ({
   },
   onDeleteEditableHtml: (e) => {
     if (e.keyCode === 8 || e.keyCode === 46) { // if backspace or delete is clicked
+      e.preventDefault();
+      e.stopPropagation();
       const selection = window.getSelection();
-      const baseIndex = $(window.getSelection().baseNode.parentNode).data('index');
-      const focusIndex = $(window.getSelection().focusNode.parentNode).data('index');
+      const baseIndex = $(window.getSelection().anchorNode.parentNode).index();
+      const focusIndex = $(window.getSelection().focusNode.parentNode).index();;
       const startIndex = Math.min(baseIndex, focusIndex);
       const endIndex = Math.max(baseIndex, focusIndex);
       dispatch(actions.onDeleteEditableHtml(startIndex, endIndex))


### PR DESCRIPTION
- as per title
- add package-lock.json to gitignore
- fixes #1 

### Fix:
1. I changed it to retrieve the index of the word based on anchorNode's parent

2. anchorNode's parent was the div of the contenteditable so the index was always 0

3. So I wrapped every single word in a span

TODO: fix focus


